### PR TITLE
Added model json edit and granite example

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,18 +191,22 @@ python3 zipnn_compress_path.py safetensors --path .
 
 Add the compressed weights to git-lfs tracking
 ```
-git lfs track "*.znn"
-git add .gitattributes
-sed -i 's/.safetensors/.safetensors.znn/g' model.safetensors.index.json
+git lfs track "*.znn" &&
+sed -i 's/.safetensors/.safetensors.znn/g' model.safetensors.index.json &&
+git add .gitattributes model.safetensors.index.json
 ```
 
 Done! Now push the changes as per [the documentation](https://huggingface.co/docs/hub/repositories-getting-started#set-up).
 
-To use the model simply clone its repository and decompress the weights by running:
+To use the model simply run our ZipNN Hugging Face patch before proceeding as normal:
+```python
+from zipnn import zipnn_hf_patch
+
+zipnn_hf_patch()
+
+# Load the model from your compressed Hugging Face model card as you normally would
+...
 ```
-python3 zipnn_decompress_path.py --path PATH_TO_CLONE
-```
-Finally, load the model from the local version.
 
 You can test [Jamba-v0.1-ZipNN-Compressed](https://huggingface.co/royleibov/Jamba-v0.1-ZipNN-Compressed) and [granite-7b-instruct-ZipNN-Compressed](https://huggingface.co/royleibov/granite-7b-instruct-ZipNN-Compressed) yourself (both compressed to 67% their original sizes - which could save ~1PB for [ai21labs Jamba-v0.1](https://huggingface.co/ai21labs/Jamba-v0.1) and ~30TB for 
 [ibm-granite granite-7b-instruct](https://huggingface.co/ibm-granite/granite-7b-instruct) of monthly downloads).

--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ Are the original and decompressed byte strings the same [BYTE]?  True
 ```
 
 
-### Example of compressing a hosted model
-In this example, ZipNN compresses a full model hosted on the Hugging Face AI-Hub. We compress [AI21Labs Jamba-v0.1](https://huggingface.co/ai21labs/Jamba-v0.1) by 33% - which could save ~1PB of monthly downloads.
+### Example of compressing a model hosted on Hugging Face
+In this example, ZipNN compresses a full model hosted on the Hugging Face AI-Hub.
 
 From the model's directory (which [can be forked locally](https://huggingface.co/docs/hub/en/repositories-next-steps#duplicating-with-the-git-history-fork)) run:
 ```
@@ -193,17 +193,19 @@ Add the compressed weights to git-lfs tracking
 ```
 git lfs track "*.znn"
 git add .gitattributes
+sed -i 's/.safetensors/.safetensors.znn/g' model.safetensors.index.json
 ```
 
 Done! Now push the changes as per [the documentation](https://huggingface.co/docs/hub/repositories-getting-started#set-up).
 
 To use the model simply clone its repository and decompress the weights by running:
 ```
-python3 zipnn_decompress_path.py
+python3 zipnn_decompress_path.py --path PATH_TO_CLONE
 ```
 Finally, load the model from the local version.
 
-You can test [Jamba-v0.1-ZipNN-Compressed](https://huggingface.co/royleibov/Jamba-v0.1-ZipNN-Compressed) yourself.
+You can test [Jamba-v0.1-ZipNN-Compressed](https://huggingface.co/royleibov/Jamba-v0.1-ZipNN-Compressed) and [granite-7b-instruct-ZipNN-Compressed](https://huggingface.co/royleibov/granite-7b-instruct-ZipNN-Compressed) yourself (both compressed to 67% their original sizes - which could save ~1PB for [ai21labs Jamba-v0.1](https://huggingface.co/ai21labs/Jamba-v0.1) and ~30TB for 
+[ibm-granite granite-7b-instruct](https://huggingface.co/ibm-granite/granite-7b-instruct) of monthly downloads).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Are the original and decompressed byte strings the same [BYTE]?  True
 ### Example of compressing a model hosted on Hugging Face
 In this example, ZipNN compresses a full model hosted on the Hugging Face AI-Hub.
 
-From the model's directory (which [can be forked locally](https://huggingface.co/docs/hub/en/repositories-next-steps#duplicating-with-the-git-history-fork)) run:
+From the model's directory (which [can be forked locally](https://huggingface.co/docs/hub/en/repositories-next-steps#duplicating-with-the-git-history-fork). Make sure you `git lfs pull upstream` before continuing) run:
 ```
 python3 zipnn_compress_path.py safetensors --path .
 ```
@@ -193,7 +193,8 @@ Add the compressed weights to git-lfs tracking
 ```
 git lfs track "*.znn" &&
 sed -i 's/.safetensors/.safetensors.znn/g' model.safetensors.index.json &&
-git add .gitattributes model.safetensors.index.json
+git add *.znn .gitattributes model.safetensors.index.json
+git rm *.safetensors
 ```
 
 Done! Now push the changes as per [the documentation](https://huggingface.co/docs/hub/repositories-getting-started#set-up).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,6 +18,7 @@ python zipnn_compress_file.py model_name
       - A string with a unit suffix (e.g., `4KB`, `2MB`, `1GB`), where the unit is interpreted as kilobytes, megabytes, or gigabytes.
     - `--delete`: Flag that specifies to delete the files instead of compressing them.
     - `--force`: Flag that forces overwriting when compressing.
+    - `--hf_cache`: A flag that indicates if the file is in the Hugging Face cache.
    
 ### `zipnn_decompress_file.py`
 
@@ -32,6 +33,7 @@ python zipnn_decompress_file.py compressed_model_name.znn
   - **Optional**:
     - `--delete`: Flag that specifies to delete the files instead of compressing them.
     - `--force`: Flag that forces overwriting when decompressing.
+    - `--hf_cache`: A flag that indicates if the file is in the Hugging Face cache.
 
 ### `zipnn_compress_path.py`
 
@@ -53,6 +55,9 @@ python zipnn_compress_path.py safetensors  --path data/
     - `-r`,`--recursive`: Both flags operate the same: they specify to look recursively in all subdirectories (of current folder or of the path given) for files with the specified suffix.
     - `--force`: Flag that forces overwriting when compressing.
     - `--max_processes`: Amount of max processes that can be used during the compression. The default is 1.
+    - `--model`: Only when using --hf_cache, specify the model name or path. E.g. 'ibm-granite/granite-7b-instruct'.
+    - `--model_branch`: Only when using --model, specify the model branch. Default is 'main'.
+    - `--hf_cache`: A flag that indicates if the file is in the Hugging Face cache. Must either specify --model or --path to the model's snapshot cache.
 
 ### `zipnn_decompress_path.py`
 
@@ -68,5 +73,8 @@ python zipnn_decompress_path.py --path data/
     - `--delete`: Flag that specifies to delete the files instead of compressing them.
     - `--force`: Flag that forces overwriting when decompressing.
     - `--max_processes`: Amount of max processes that can be used during the decompression. The default is 1.
+    - `--model`: Only when using --hf_cache, specify the model name or path. E.g. 'ibm-granite/granite-7b-instruct'.
+    - `--model_branch`: Only when using --model, specify the model branch. Default is 'main'.
+    - `--hf_cache`: A flag that indicates if the file is in the Hugging Face cache. Must either specify --model or --path to the model's snapshot cache.
 
 To use these scripts, simply copy the desired file to your project directory and run it as needed.

--- a/zipnn/__init__.py
+++ b/zipnn/__init__.py
@@ -1,1 +1,1 @@
-from .zipnn import ZipNN
+from .zipnn import ZipNN, zipnn_hf_patch


### PR DESCRIPTION
The model JSON edit is needed to allow the regular use of from_pretrained if we change the Hugging Face loading code, and could actually break the usage of loading with from_pretrained locally. We need to think of if we even want to include that line at the moment. (sed -i 's/.safetensors/.safetensors.znn/g' model.safetensors.index.json) <- this line
Added the granite compressed example.