### PR TITLE
Added support for non-sharded models from huggingface

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Add the compressed weights to git-lfs tracking
 ```
 git lfs track "*.znn" &&
 sed -i 's/.safetensors/.safetensors.znn/g' model.safetensors.index.json &&
-git add *.znn .gitattributes model.safetensors.index.json
+git add *.znn .gitattributes model.safetensors.index.json &&
 git rm *.safetensors
 ```
 
@@ -205,9 +205,9 @@ Done! Now push the changes as per [the documentation](https://huggingface.co/doc
 
 To use the model simply run our ZipNN Hugging Face patch before proceeding as normal:
 ```python
-from zipnn import zipnn_hf_patch
+from zipnn import zipnn_hf
 
-zipnn_hf_patch()
+zipnn_hf()
 
 # Load the model from your compressed Hugging Face model card as you normally would
 ...

--- a/scripts/zipnn_compress_file.py
+++ b/scripts/zipnn_compress_file.py
@@ -10,6 +10,10 @@ KB = 1024
 MB = 1024 * 1024
 GB = 1024 * 1024 * 1024
 
+RED = "\033[91m"
+YELLOW = "\033[93m"
+GREEN = "\033[92m"
+RESET = "\033[0m"
 
 def check_and_install_zipnn():
     try:
@@ -63,7 +67,7 @@ def compress_file(
     streaming_chunk_size = parse_streaming_chunk_size(streaming_chunk_size)
     full_path = input_file
     if not os.path.exists(full_path):
-        print("File not found")
+        print(f"{RED}File not found{RESET}")
         return
     if delete and not hf_cache:
         print(f"Deleting {full_path}...")
@@ -104,12 +108,12 @@ def compress_file(
         end_time = time.time() - start_time
         print(f"Compressed {input_file} to {output_file}")
         print(
-            f"Original size:  {file_size_before/GB:.02f}GB size after compression: {file_size_after/GB:.02f}GB, Remaining size is {file_size_after/file_size_before*100:.02f}% of original, time: {end_time:.02f}"
+            f"{GREEN}Original size:  {file_size_before/GB:.02f}GB size after compression: {file_size_after/GB:.02f}GB, Remaining size is {file_size_after/file_size_before*100:.02f}% of original, time: {end_time:.02f}{RESET}"
         )
 
         if hf_cache:
             # If the file is in the Hugging Face cache, fix the symlinks
-            print("Reorganizing Hugging Face cache...")
+            print(f"{YELLOW}Reorganizing Hugging Face cache...{RESET}")
             try:
                 snapshot_path = os.path.dirname(input_file)
                 blob_name = os.path.join(snapshot_path, os.readlink(input_file))

--- a/scripts/zipnn_compress_path.py
+++ b/scripts/zipnn_compress_path.py
@@ -21,6 +21,11 @@ KB = 1024
 MB = 1024 * 1024
 GB = 1024 * 1024 * 1024
 
+RED = "\033[91m"
+YELLOW = "\033[93m"
+GREEN = "\033[92m"
+RESET = "\033[0m"
+
 
 def check_and_install_zipnn():
     try:
@@ -188,7 +193,7 @@ def compress_files_with_suffix(
             )
         
         if os.path.exists(os.path.join(path, SAFE_WEIGHTS_INDEX_NAME)):
-            print("Fixing Hugging Face model json...")
+            print(f"{YELLOW}Fixing Hugging Face model json...{RESET}")
             blob_name = os.path.join(path, os.readlink(os.path.join(path, SAFE_WEIGHTS_INDEX_NAME)))
             subprocess.check_call(
             [
@@ -199,7 +204,7 @@ def compress_files_with_suffix(
             ]
             )
         elif os.path.exists(os.path.join(path, WEIGHTS_INDEX_NAME)):
-            print("Fixing Hugging Face model json...")
+            print(f"{YELLOW}Fixing Hugging Face model json...{RESET}")
             blob_name = os.path.join(path, os.readlink(os.path.join(path, WEIGHTS_INDEX_NAME)))
             subprocess.check_call(
             [
@@ -236,7 +241,7 @@ def compress_files_with_suffix(
                     future.result()
                 except Exception as exc:
                     print(
-                        f"File {file} generated an exception: {exc}"
+                        f"{RED}File {file} generated an exception: {exc}{RESET}"
                     )
 
                 if file_list:
@@ -255,8 +260,10 @@ def compress_files_with_suffix(
 
     if not files_found:
         print(
-            f"No files with the suffix '{suffix}' found."
+            f"{RED}No files with the suffix '{suffix}' found.{RESET}"
         )
+
+    print(f"{GREEN}All files compressed{RESET}")
 
 
 if __name__ == "__main__":

--- a/scripts/zipnn_decompress_file.py
+++ b/scripts/zipnn_decompress_file.py
@@ -5,6 +5,11 @@ import argparse
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+RED = "\033[91m"
+YELLOW = "\033[93m"
+GREEN = "\033[92m"
+RESET = "\033[0m"
+
 
 def check_and_install_zipnn():
     try:
@@ -15,7 +20,7 @@ def check_and_install_zipnn():
         import zipnn
 
 
-def decompress_file(input_file, delete=False, force=False, hf_cache=False,):
+def decompress_file(input_file, delete=False, force=False, hf_cache=False):
     import zipnn
 
     if not input_file.endswith(".znn"):
@@ -50,15 +55,14 @@ def decompress_file(input_file, delete=False, force=False, hf_cache=False,):
 
             if hf_cache:
                 # If the file is in the Hugging Face cache, fix the symlinks
-                print("Reorganizing Hugging Face cache...")
+                print(f"{YELLOW}Reorganizing Hugging Face cache...{RESET}")
                 try:
                     snapshot_path = os.path.dirname(input_file)
                     blob_name = os.path.join(snapshot_path, os.readlink(input_file))
                     os.rename(output_file, blob_name)
                     os.symlink(blob_name, output_file)
                     
-                    print("To delete the original compressed file, run the script with the --delete flag.")
-                    if os.path.exists(input_file) and delete:
+                    if os.path.exists(input_file):
                         os.remove(input_file)
                 except Exception as e:
                     raise Exception(f"Error reorganizing Hugging Face cache: {e}")

--- a/scripts/zipnn_decompress_path.py
+++ b/scripts/zipnn_decompress_path.py
@@ -19,6 +19,10 @@ sys.path.append(
     )
 )
 
+RED = "\033[91m"
+YELLOW = "\033[93m"
+GREEN = "\033[92m"
+RESET = "\033[0m"
 
 def check_and_install_zipnn():
     try:
@@ -156,7 +160,7 @@ def decompress_znn_files(
         suffix = file_list[0].split('/')[-1].split('.')[-2] # get the one before .znn
 
         if os.path.exists(os.path.join(path, SAFE_WEIGHTS_INDEX_NAME)):
-            print("Fixing Hugging Face model json...")
+            print(f"{YELLOW}Fixing Hugging Face model json...{RESET}")
             blob_name = os.path.join(path, os.readlink(os.path.join(path, SAFE_WEIGHTS_INDEX_NAME)))
             subprocess.check_call(
             [
@@ -167,7 +171,7 @@ def decompress_znn_files(
             ]
             )
         elif os.path.exists(os.path.join(path, WEIGHTS_INDEX_NAME)):
-            print("Fixing Hugging Face model json...")
+            print(f"{YELLOW}Fixing Hugging Face model json...{RESET}")
             blob_name = os.path.join(path, os.readlink(os.path.join(path, WEIGHTS_INDEX_NAME)))
             subprocess.check_call(
             [
@@ -188,6 +192,7 @@ def decompress_znn_files(
                     file,
                     delete,
                     True,
+                    hf_cache,
                 ): file
                 for file in file_list[
                     :max_processes
@@ -207,7 +212,7 @@ def decompress_znn_files(
                         future.result()
                     except Exception as exc:
                         print(
-                            f"File {file} generated an exception: {exc}"
+                            f"{RED}File {file} generated an exception: {exc}{RESET}"
                         )
 
                     if file_list:
@@ -220,9 +225,11 @@ def decompress_znn_files(
                                 next_file,
                                 delete,
                                 True,
+                                hf_cache,
                             )
                         ] = next_file
                         #
+    print(f"{GREEN}All files decompressed{RESET}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixed scripts and added support for single file models. Tested a bunch of edge cases but there could be more I missed.
Notice the comment I made in custom_from_pretrained ("# Skipping user_agent["quant"]! Could be a problem"). user_agent is used to make the url header to query hf, I don't know what the use of quant in this case, maybe for some edge case they had, but it was too involved (and unnecessary in my opinion) to go though setting it up like they did under transformers.modeling_utils. Just wanted to point that out. (link to where quant is relevant in hf https://github.com/huggingface/transformers/blob/2b789f27f383435b8db2fee3d10b0a1358c0c234/src/transformers/modeling_utils.py#L3400)