### PR TITLE
cleanup - typo and NULL return

### DIFF
--- a/csrc/split_dtype16.c
+++ b/csrc/split_dtype16.c
@@ -503,11 +503,11 @@ PyObject *py_combine_dtype16(PyObject *self, PyObject *args) {
 
         if (HUF_isError(decompressedSize)) {
           HUF_getErrorName(decompressedSize);
-          return 0;
+          return NULL;
         }
 
         if (decompressedSize != decompLen[c]) {
-          return 0;
+          return NULL;
         }
       }
     }

--- a/zipnn/zipnn.py
+++ b/zipnn/zipnn.py
@@ -1316,7 +1316,7 @@ def zipnn_hf():
     PreTrainedModel.from_pretrained = classmethod(custom_from_pretrained)
 
 def replace_in_file(file_path, old: str, new: str) -> None:
-    """Given a file_path, replace all occurrences of `old` with `new` inpalce."""
+    """Given a file_path, replace all occurrences of `old` with `new` inplace."""
 
     with open(file_path, 'r') as file:
         file_data = file.read()


### PR DESCRIPTION
Just some minor cleanup:
1. A typo in a comment
2. Replace return 0 with return NULL to be consistent